### PR TITLE
Update AutOSINT.py

### DIFF
--- a/AutOSINT.py
+++ b/AutOSINT.py
@@ -11,7 +11,7 @@
 #try:
 
 #builtins
-import argparse, time, os, sys, re
+import argparse, time, os, sys, re, socket
 
 #AutOSINT module imports
 from modules.whois import Whois


### PR DESCRIPTION
because of Error Message

==> nameError: global name 'socket' is not defined